### PR TITLE
Logout when token expired

### DIFF
--- a/client/src/modules/user.module.ts
+++ b/client/src/modules/user.module.ts
@@ -21,8 +21,10 @@ class _User {
             this.expires = null;
         } 
 
-        if(this.access_token && this.refresh_token && this.expires) {
+        if(this.access_token) {
             this.checkExpiration()
+            
+            if(!document.cookie.includes("token=")) this.logout();
         }
 
         console.log('User initialized')
@@ -58,10 +60,12 @@ class _User {
         localStorage.removeItem('refresh_token');
         localStorage.removeItem('expires')
         
-        APIService.revokeAccessToken(this.access_token!)
+        if(this.access_token) {
+            APIService.revokeAccessToken(this.access_token)
             .then(() => {
                 window.location.href = '/';
             })
+        }
     }
 
     get getIsLoggedIn() {


### PR DESCRIPTION
## Summary
Log person out when their token is expired, especially useful for people who use Brave browser and have a cookie max age of 1 week. If the person still has an access token then revoke this token

## How to test
1. In the code change the cookie max age to something small like 10 seconds
2. Relog
3. After your set time reload the page and see that you got logged out
